### PR TITLE
Make sure all paths through the main window event filter return

### DIFF
--- a/MiniZincIDE/mainwindow.cpp
+++ b/MiniZincIDE/mainwindow.cpp
@@ -2396,9 +2396,8 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *ev)
                 return true;
             }
         }
-    } else {
-        return QMainWindow::eventFilter(obj,ev);
     }
+    return QMainWindow::eventFilter(obj,ev);
 }
 
 void MainWindow::on_actionCheat_Sheet_triggered()


### PR DESCRIPTION
If the missing return became "true", findWidget events except for escape key presses would be dropped, including draw events.