### PR TITLE
Fix signature for signal/slots using MessageWrapper

### DIFF
--- a/cp-profiler/src/cpprofiler/message_wrapper.hh
+++ b/cp-profiler/src/cpprofiler/message_wrapper.hh
@@ -22,6 +22,7 @@ public:
     MessageWrapper(const Message& msg): _msg(msg) {}
 
     Message& msg() { return _msg; }
+    const Message& msg() const { return _msg; }
 
 private:
     Message _msg;

--- a/cp-profiler/src/cpprofiler/receiver_thread.hh
+++ b/cp-profiler/src/cpprofiler/receiver_thread.hh
@@ -28,7 +28,7 @@ class ReceiverThread : public QThread
   signals:
 
     void notifyStart(const std::string &ex_name, int ex_id, bool restarts);
-    void newNode(MessageWrapper& node);
+    void newNode(const cpprofiler::MessageWrapper& node);
     void doneReceiving();
 
   public:

--- a/cp-profiler/src/cpprofiler/receiver_worker.hh
+++ b/cp-profiler/src/cpprofiler/receiver_worker.hh
@@ -54,7 +54,7 @@ class ReceiverWorker : public QObject
   signals:
 
     void notifyStart(const std::string &ex_name, int ex_id, bool restarts);
-    void newNode(MessageWrapper& node);
+    void newNode(const cpprofiler::MessageWrapper& node);
     void doneReceiving();
 
   public:

--- a/cp-profiler/src/cpprofiler/tree_builder.cpp
+++ b/cp-profiler/src/cpprofiler/tree_builder.cpp
@@ -70,7 +70,7 @@ void TreeBuilder::finishBuilding()
     emit buildingDone();
 }
 
-void TreeBuilder::handleNode(MessageWrapper& node)
+void TreeBuilder::handleNode(const MessageWrapper& node)
 {
     // print("node: {}", *node);
     auto& msg = node.msg();

--- a/cp-profiler/src/cpprofiler/tree_builder.hh
+++ b/cp-profiler/src/cpprofiler/tree_builder.hh
@@ -26,7 +26,7 @@ class TreeBuilder : public QObject
 
     void finishBuilding();
 
-    void handleNode(MessageWrapper& node);
+    void handleNode(const cpprofiler::MessageWrapper& node);
 
   signals:
 


### PR DESCRIPTION
When connections are queued or across threads, Qt copies the arguments.
It uses the normalized signature [1] to determine the wanted type, which
has to made known via qRegisterType.

As only "MessageWrapper" is registered, but not "MessageWrapper&" (mind
the reference), this fails:

```
QObject::connect: Cannot queue arguments of type 'MessageWrapper&'
(Make sure 'MessageWrapper&' is registered using qRegisterMetaType().)
```

Use `const cpprofiler::MessageWrapper&` as it gets normalized to
`cpprofiler::MessageWrapper`, and using a const& avoids some copies.
In the header files use the fully qualified name, as this is what
Moc uses for creating the metaobject, this must match the type
in Q_DECLARE_METATYPE verbatim.

[1] https://doc.qt.io/qt-5/qmetaobject.html#normalizedSignature